### PR TITLE
Tidying CEs

### DIFF
--- a/ConfigurationSystem/Agent/AutoBdii2CSAgent.py
+++ b/ConfigurationSystem/Agent/AutoBdii2CSAgent.py
@@ -16,7 +16,8 @@ __RCSID__ = "$Id$"
 from DIRAC import S_OK
 from DIRAC.ConfigurationSystem.Agent.Bdii2CSAgent import Bdii2CSAgent
 from GridPPDIRAC.ConfigurationSystem.private.AddResourceAPI import (checkUnusedCEs,
-                                                                    checkUnusedSEs)
+                                                                    checkUnusedSEs,
+                                                                    removeOldCEs)
 
 
 class AutoBdii2CSAgent(Bdii2CSAgent):
@@ -43,6 +44,8 @@ class AutoBdii2CSAgent(Bdii2CSAgent):
         self.domain = self.am_getOption('Domain', 'LCG')
         self.country_default = self.am_getOption('CountryCodeDefault', 'xx')
         self.bdii_host = self.am_getOption('BDIIHost', None)
+        self.removeOldCEs = self.am_getOption('RemoveOldCEs', True)
+        self.ce_removal_threshold = self.am_getOption('CERemovalThreshold', 5)
         return Bdii2CSAgent.initialize(self)
 
     def execute(self):
@@ -70,5 +73,10 @@ class AutoBdii2CSAgent(Bdii2CSAgent):
                                    "in the VO %s: %s"
                                    % (vo, result['Message']))
                     continue
+        if self.removeOldCEs:
+            result = removeOldCEs(self.ce_removal_threshold, self.domain)
+            if not result['OK']:
+                self.log.error("Error while running removal of old CEs: "
+                               "%s" % result['Message'])
 
         return S_OK()

--- a/ConfigurationSystem/private/AddResourceAPI.py
+++ b/ConfigurationSystem/private/AddResourceAPI.py
@@ -37,8 +37,7 @@ class _ConfigurationSystem(CSAPI):
         """initialise"""
         CSAPI.__init__(self)
         self._num_changes = 0
-        self.initialize()
-        result = self.downloadCSData()
+        result = self.initialize()
         if not result['OK']:
             gLogger.error('Failed to initialise CSAPI object', result['Message'])
             raise RuntimeError(result['Message'])   

--- a/ConfigurationSystem/private/AddResourceAPI.py
+++ b/ConfigurationSystem/private/AddResourceAPI.py
@@ -4,7 +4,7 @@ API for adding resources to CS
 """
 import os
 import re
-from datetime import datetime, date
+from datetime import datetime, date, timedelta
 from types import GeneratorType
 from urlparse import urlparse
 from DIRAC import gLogger, gConfig, S_OK, S_ERROR

--- a/ConfigurationSystem/private/AddResourceAPI.py
+++ b/ConfigurationSystem/private/AddResourceAPI.py
@@ -153,12 +153,12 @@ def removeOldCEs(threshold=5, domain='LCG'):
     Remove CEs that have not been seen for a given time
     '''
     cs = _ConfigurationSystem()
-    base_path = cfgPath('/Resources/Sites', domain)
-    result = gConfig.getOptionsDict(base_path)
+    result = cs.getCurrentCFG()
     if not result['OK']:
         gLogger.error('Could not get current sites from the CS')
         return result
-    site_dict = result['Value']
+    base_path = cfgPath('/Resources/Sites', domain)
+    site_dict = result['Value'].getAsDict(base_path)
     for site, site_info in site_dict.iteritems():
         site_path = cfgPath(base_path, site)
         for ce, ce_info in site_info.get('CEs', {}).iteritems():

--- a/ConfigurationSystem/private/AddResourceAPI.py
+++ b/ConfigurationSystem/private/AddResourceAPI.py
@@ -31,7 +31,10 @@ __all__ = ['checkUnusedCEs', 'checkUnusedSEs', 'removeOldCEs']
 
 
 class _ConfigurationSystem(CSAPI):
+    """ Class to smartly wrap the functionality of the CS"""
+
     def __init__(self):
+        """initialise"""
         CSAPI.__init__(self)
         self._num_changes = 0
         self.initialize()
@@ -41,6 +44,19 @@ class _ConfigurationSystem(CSAPI):
             raise RuntimeError(result['Message'])   
 
     def add(self, section, option, new_value):
+        """
+        Add a value into the configuration system.
+
+        This method will overwrite any existing option's value.
+
+        Args:
+            section (str): The section
+            option (str): The option to be created/modified
+            new_value: The value to be assigned
+
+        Example:
+            >>> _ConfigurationSystem().add('/Registry', 'DefaultGroup', 'dteam_user')
+        """
         if isinstance(new_value, (tuple, list, set, GeneratorType)):
             new_value = ', '.join(sorted(map(str, new_value)))
         else:
@@ -61,6 +77,12 @@ class _ConfigurationSystem(CSAPI):
         self._num_changes+=1
 
     def append_unique(self, section, option, new_value):
+        """
+        Append a value onto the end of an existing CS option.
+
+        This method is like append except that it ensures that the final list
+        of values for the given option only contains unique entries.
+        """
         old_values = set(v.strip() for v in gConfig.getValue(cfgPath(section, option), '').split(',') if v)
 
         if isinstance(new_value, (tuple, list, set)):
@@ -70,6 +92,13 @@ class _ConfigurationSystem(CSAPI):
         self.add(section, option, old_values)
 
     def append(self, section, option, new_value):
+        """
+        Append a value onto the end of an existing CS option.
+
+        This method is like add with the exception that the new value
+        is appended on to the end of the list of values associated
+        with that option.
+        """
         old_values = [v.strip() for v in gConfig.getValue(cfgPath(section, option), '').split(',') if v]
 
         if isinstance(new_value, (tuple, list, set)):
@@ -79,6 +108,20 @@ class _ConfigurationSystem(CSAPI):
         self.add(section, option, old_values)
             
     def remove(self, section, option=None):
+        """
+        Remove a section/option from the configuration system.
+
+        This method will remove the specified section if the option argument
+        is None (default). If the option argument is given then that option
+        (formed of section/option) is removed.
+
+        Args:
+            section (str): The section
+            option (str): [optional] The option
+
+        Example:
+            >>> _ConfigurationSystem().remove('/Registry', 'DefaultGroup')
+        """
         if option is None:
             gLogger.notice("Removing section %s" % section)
             self.delSection(section)
@@ -88,6 +131,12 @@ class _ConfigurationSystem(CSAPI):
         self._num_changes+=1
 
     def commit(self):
+        """
+        Commit the changes to the configuration system.
+
+        Returns:
+            dict: S_OK/S_ERROR DIRAC style dicts
+        """
         result = CSAPI.commit(self)
         if not result['OK']:
             gLogger.error("Error while commit to CS", result['Message'])


### PR DESCRIPTION
This pull fixes ic-hep/DIRAC#45

When updating the CEs in the configuration system, It adds an extra attribute to each CE in the BDII which is effectively a datestamp for the day that it has been seen. There is now a final step in the Agent which loops through all CEs in the CS and removes any with a datestamp older that a given threshold (default 5 days).

@sfayer please review and merge