### PR TITLE
Populate VO when only single vo listed in BDII

### DIFF
--- a/ConfigurationSystem/private/AddResourceAPI.py
+++ b/ConfigurationSystem/private/AddResourceAPI.py
@@ -240,6 +240,8 @@ def checkUnusedCEs(vo, host=None, domain='LCG', country_default='xx'):
                 ce_type = queue_info.get('GlueCEImplementationName', '')
                 max_cpu_time = queue_info.get('GlueCEPolicyMaxCPUTime')
                 acbr = queue_info.get('GlueCEAccessControlBaseRule')
+                if not isinstance(acbr, (list, tuple, set)):
+                    acbr = [acbr]
                 vos = set((rule.replace('VO:', '') for rule in acbr
                            if rule.startswith('VO:')))
                 q_si00 = ''


### PR DESCRIPTION
This fixes https://github.com/ic-hep/DIRAC/issues/47

Seems that for the PBS queues VO attribute was left blank. This was because the queue
only reported one VO association and the dirac command to pass BDII didn't return a
single element list but the vo string itself.

        modified:   AddResourceAPI.py