### PR TITLE
Modify VOPath Logic

### DIFF
--- a/ConfigurationSystem/private/AddResourceAPI.py
+++ b/ConfigurationSystem/private/AddResourceAPI.py
@@ -464,17 +464,14 @@ def checkUnusedSEs(vo, host=None, banned_ses=None):
 
             old_path = gConfig.getValue(cfgPath(accessSection, 'Path'), None)
             path = vo_info.get(se, {}).get('Path')
-            vo_path = vo_info.get(se, {}).get('VOPath')
+            vo_path = vo_info.get(se, {}).get('VOPath') or os.path.join(path, vo)
 
             # If path is different from last VO then we just default the
             # path to / and use the VOPath dict
             if old_path and path and path != old_path:
-                vo_path = vo_path or os.path.join(path, vo)
                 path = '/'
 
-            if vo_path:
-                changeSet.add(vopathSection, vo, vo_path)
-
+            changeSet.add(vopathSection, vo, vo_path)
             changeSet.add(accessSection, 'Protocol', 'srm')
             changeSet.add(accessSection, 'ProtocolName', 'SRM2')
             changeSet.add(accessSection, 'Port', port)


### PR DESCRIPTION
Now we create a VOPath directory in the config even if all VOs have the same path. This  fixes https://github.com/ic-hep/DIRAC/issues/50

	modified:   ConfigurationSystem/private/AddResourceAPI.py