### PR TITLE
Don't include bogus SEs

### DIFF
--- a/ConfigurationSystem/private/AddResourceAPI.py
+++ b/ConfigurationSystem/private/AddResourceAPI.py
@@ -407,7 +407,7 @@ def checkUnusedSEs(vo, host=None, banned_ses=None):
     if not result['OK']:
         return result
     ses = dict(((i['GlueSEUniqueID'], i) for i in result['Value']
-                if 'GlueSEUniqueID' in i))
+                if '.' in i.get('GlueSEUniqueID', '')))
 
     result = ldapService(serviceType='SRM', vo=vo, host=host)
     if not result['OK']:


### PR DESCRIPTION
This patch ignores SEs in the BDII with GlueSEUniqueID that doesn't contain the '.' character. This removes bogus SE entries like Purdue-Hadoop, SWT2_CPB or BNL_ATLAS_CLASSIC.

This is the final piece of the fix https://github.com/ic-hep/DIRAC/issues/53