### PR TITLE
Add new rules for searching for VO SEs

### DIFF
--- a/ConfigurationSystem/private/AddResourceAPI.py
+++ b/ConfigurationSystem/private/AddResourceAPI.py
@@ -367,9 +367,11 @@ def _ldap_vo_info(vo_name, host=None):
     vo_filter = '(GlueVOInfoAccessControlBaseRule=VOMS:/%s/*)' % vo_name
     vo_filter += '(GlueVOInfoAccessControlBaseRule=VOMS:/%s)' % vo_name
     vo_filter += '(GlueVOInfoAccessControlBaseRule=VO:%s)' % vo_name
+    vo_filter += '(GlueVOInfoAccessControlBaseRule=%s)' % vo_name
     vo_filter += '(GlueVOInfoAccessControlRule=VOMS:/%s/*)' % vo_name
     vo_filter += '(GlueVOInfoAccessControlRule=VOMS:/%s)' % vo_name
     vo_filter += '(GlueVOInfoAccessControlRule=VO:%s)' % vo_name
+    vo_filter += '(GlueVOInfoAccessControlRule=%s)' % vo_name
     filt = '(&(objectClass=GlueVOInfo)(|%s))' % vo_filter
     result = ldapsearchBDII(filt=filt, host=host)
     if not result['OK']:
@@ -477,6 +479,9 @@ def checkUnusedSEs(vo, host=None, banned_ses=None):
 
             old_path = gConfig.getValue(cfgPath(accessSection, 'Path'), None)
             path = vo_info.get(se, {}).get('Path')
+            if path is None:
+                gLogger.warn("Cannot find 'Path' for vo: %s, se: %s...skipping" % (vo, se))
+                continue
             vo_path = vo_info.get(se, {}).get('VOPath') or os.path.join(path, vo)
 
             # If path is different from last VO then we just default the


### PR DESCRIPTION
This is a fix for when some VOs define different AccessControl info without leading slashes. It also includes a trap to catch (hopefully) and further problems with the BDII AcessControl field.

Note this fix includes part of that from https://github.com/ic-hep/DIRAC/pull/55

	modified:   ConfigurationSystem/private/AddResourceAPI.py