### PR TITLE
fixing bdii keyerror.

### DIFF
--- a/ConfigurationSystem/private/AddResourceAPI.py
+++ b/ConfigurationSystem/private/AddResourceAPI.py
@@ -206,7 +206,12 @@ def checkUnusedCEs(vo, host=None, domain='LCG',
     if banned_ces is None:
         banned_ces = []
 
-    result = getBdiiCEInfo(vo, host=host)
+    try:
+        result = getBdiiCEInfo(vo, host=host)
+    except KeyError as e:
+        msg = "Problem getting BDII info: %s" % e.message
+        gLogger.error(msg)
+        return S_ERROR(msg)
     if not result['OK']:
         gLogger.error("Problem getting BDII info")
         return result


### PR DESCRIPTION
Fixes issue discovered while looking into https://github.com/ic-hep/DIRAC/issues/72 whereby using the CERN BDII yielded unpredictable results and siteID key errors in the DIRAC code, namely of the form:

```python
Traceback (most recent call last):
  File "AddResourceAPI.py", line 540, in <module>
    domain=options.domain)
  File "AddResourceAPI.py", line 209, in checkUnusedCEs
    result = getBdiiCEInfo(vo, host=host)
  File "/opt/dirac/DIRAC/Core/Utilities/Grid.py", line 433, in getBdiiCEInfo
    siteID = ceDict[ceID]['Site']
KeyError: 'ce8.glite.ecdf.ed.ac.uk'
```