### PR TITLE
Remove duplicate Travis CI builds in PR status.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,9 @@ script:
   - py.test
 after_success:
   - coveralls
+
+# only commits to master trigger a bulid
+# other branches are build on PR.
+branches:
+  only:
+    - master


### PR DESCRIPTION
Travis triggers builds when a commit is pushed to any branch by default and also
attempts to build a PR. This causes two builds on a pull request status. These builds are slightly
different but probably only the PR one is what you want. The solution is to specify only the master branch
is built on push but that pull requests are still built.