### PR TITLE
Fix for missing LDAP helper functions under DIRAC v7.

### DIFF
--- a/ConfigurationSystem/Agent/AutoBdii2CSAgent.py
+++ b/ConfigurationSystem/Agent/AutoBdii2CSAgent.py
@@ -68,14 +68,13 @@ class AutoBdii2CSAgent(Bdii2CSAgent):
         """General agent execution method."""
         # Update SEs
         ##############################
-        if self.processSEs:
-            url = urlparse('//%s' % self.bdii_host)
-            try:
-                update_ses(self.voName,
-                           address=(url.hostname, url.port if url.port is not None else 2170),
-                           banned_ses=self.banned_ses)
-            except Exception:
-                self.log.exception("Error while running check for new SEs")
+        url = urlparse('//%s' % self.bdii_host)
+        try:
+            update_ses(self.voName,
+                       address=(url.hostname, url.port if url.port is not None else 2170),
+                       banned_ses=self.banned_ses)
+        except Exception:
+            self.log.exception("Error while running check for new SEs")
 
         # Update CEs
         ##############################

--- a/ConfigurationSystem/private/AddResourceAPI.py
+++ b/ConfigurationSystem/private/AddResourceAPI.py
@@ -3,7 +3,7 @@ from datetime import date, datetime, timedelta
 from urlparse import urlparse
 from DIRAC import gLogger
 from DIRAC.ConfigurationSystem.Client.Helpers.Path import cfgPath
-from DIRAC.Core.Utilities.Grid import ldapSE, ldapService, getBdiiCEInfo
+from DIRAC.Core.Utilities.Grid import getBdiiCEInfo
 from .AutoResourceTools.utils import get_se_vo_info, get_xrootd_ports
 from .AutoResourceTools.ConfigurationSystem import ConfigurationSystem
 from .AutoResourceTools.SETypes import SE

--- a/ConfigurationSystem/private/AutoResourceTools/utils.py
+++ b/ConfigurationSystem/private/AutoResourceTools/utils.py
@@ -4,7 +4,21 @@ from collections import defaultdict
 from urlparse import urlparse
 from DIRAC import gLogger
 from DIRAC.ConfigurationSystem.Client.Helpers.Path import cfgPath
-from DIRAC.Core.Utilities.Grid import ldapSEAccessProtocol, ldapsearchBDII
+from DIRAC.Core.Utilities.Grid import ldapsearchBDII
+from DIRAC.Core.Utilities.ReturnValues import S_OK
+
+
+def ldapSEAccessProtocol( se, attr = None, host = None ):
+    """ SE access protocol information from bdii
+      :param  se: se or part of it with globing, for example, "ce0?.tier2.hep.manchester*"
+      :return: standard DIRAC answer with Value equals to list of access protocols.
+    """
+    filt = '(&(objectClass=GlueSEAccessProtocol)(GlueChunkKey=GlueSEUniqueID=%s))' % se
+    result = ldapsearchBDII( filt, attr, host )
+
+    if not result['OK']:
+        return result
+    return S_OK([value["attr"] for value in result['Value']])
 
 
 class WritableMixin(object):


### PR DESCRIPTION
fix https://github.com/ic-hep/DIRAC/issues/104 (first attempt)

@sfayer this is a quick fix for the specific imports you mention. I haven't tried it on a dev box so please feel free to do so.